### PR TITLE
fix(assert): json assertion type not match / repsonse body length=0 EOF

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -78,7 +78,7 @@ var runCmd = &cobra.Command{
 				return
 			}
 
-			log.Info("runConfig: %v", runConfig)
+			// log.Info("runConfig: %v", runConfig)
 		}
 
 		if len(args) == 0 && len(runConfig.Order) == 0 {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -394,12 +394,16 @@ func doAssertions(
 		}
 
 		if f != nil {
-			// err = binding.JSON.BindBody(body, &jsonData)
-			err = f.BindBody(body, &jsonData)
-			if err != nil {
-				stats.AddFailMessage("binding.json fail: %s", err)
-				stats.IncrFailAssertCountByN(int64(len(c.Assert.JSON)))
-				return
+			if len(body) != 0 {
+				err = f.BindBody(body, &jsonData)
+				if err != nil {
+					stats.AddFailMessage("binding.json fail: %s", err)
+					stats.IncrFailAssertCountByN(int64(len(c.Assert.JSON)))
+					return
+				}
+			} else {
+				// the http method: head got no response body, but header is application/json
+				jsonData = nil
 			}
 
 			if allKeys.Has("assert.json") && len(c.Assert.JSON) > 0 {

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,0 +1,13 @@
+debug: false
+render: true
+failFast: true
+timeout: 2000
+env:
+  hello: world
+  name: tom
+  host: 'http://httpbin.org'
+  content_type: application/json
+  array:
+    - a
+    - b
+    - c

--- a/examples/config_order.yaml
+++ b/examples/config_order.yaml
@@ -1,0 +1,17 @@
+debug: false
+render: true
+failFast: true
+timeout: 2000
+env:
+  hello: world
+  name: tom
+  host: 'http://httpbin.org'
+  content_type: application/json
+  array:
+    - a
+    - b
+    - c
+order:
+  - pattern: examples/http_post.toml
+  - pattern: examples/http_get.toml
+  - pattern: examples/http_*

--- a/examples/request_use_template.yaml
+++ b/examples/request_use_template.yaml
@@ -1,0 +1,19 @@
+title: http method post, use template
+description: http method post use template
+request:
+  method: post
+  url: '{{.host}}/post'
+  body: |
+    {
+        "hello": "{{.name}}",
+        "world": {{if .debug}}"in debug mode"{{else}}"not debug mode"{{end}},
+        "array": "{{range $i, $a := .array}} {{$i}}{{$a}} {{end}}"
+    }
+  header:
+    Content-Type: '{{.content_type}}'
+assert:
+  status: ok
+  statusCode: 200
+  contentLength_gt: 180
+  contentType: '{{.content_type}}'
+

--- a/examples/request_use_template_local.yaml
+++ b/examples/request_use_template_local.yaml
@@ -1,0 +1,21 @@
+title: 'http method post, use template local'
+description: http method post, use template local
+request:
+  method: post
+  url: '{{.host}}/post'
+  body: |
+    {
+        "hello": "{{.name}}",
+        "world": {{if .debug}}"in debug mode"{{else}}"not debug mode"{{end}},
+        "array": "{{range $i, $a := .array}} {{$i}}{{$a}} {{end}}"
+    }
+  header:
+    Content-Type: '{{.content_type}}'
+env:
+  name: jerry
+assert:
+  status: ok
+  statusCode: 200
+  contentLength_gt: 180
+  contentType: '{{.content_type}}'
+

--- a/pkg/assertion/header.go
+++ b/pkg/assertion/header.go
@@ -11,7 +11,7 @@ import (
 
 func DoHeaderAssertions(c config.Case, respHeader http.Header) (stats util.Stats) {
 	for key, value := range c.Assert.Header {
-		stats.AddInfoMessage("assert.header.%s: ", key)
+		stats.AddInfofMessage("assert.header.%s: ", key)
 		ok, message := assert.Equal(respHeader.Get(key), value)
 		if ok {
 			stats.AddPassMessage()

--- a/pkg/assertion/json.go
+++ b/pkg/assertion/json.go
@@ -1,6 +1,7 @@
 package assertion
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/jmespath/go-jmespath"
@@ -40,11 +41,37 @@ func DoJSONAssertions(jsonData interface{}, jsons []config.AssertJSON) (stats ut
 				continue
 			}
 
+			actualValueKind := reflect.TypeOf(actualValue).Kind()
+			expectedValueKind := reflect.TypeOf(expectedValue).Kind()
+
+			// cast to same type, float64 or int64
+			if actualValueKind != expectedValueKind && isNumberKind(actualValueKind) && isNumberKind(expectedValueKind) {
+				if isFloatKind(actualValueKind) || isFloatKind(expectedValueKind) {
+					newActualValue, err := toFloat64(actualValue)
+					if err == nil {
+						actualValue = newActualValue
+					}
+					newExpectedValue, err := toFloat64(expectedValue)
+					if err == nil {
+						expectedValue = newExpectedValue
+					}
+				} else {
+					newActualValue, err := toInt64(actualValue)
+					if err == nil {
+						actualValue = newActualValue
+					}
+					newExpectedValue, err := toInt64(expectedValue)
+					if err == nil {
+						expectedValue = newExpectedValue
+					}
+				}
+			}
+
 			// fmt.Printf("%T, %T", actualValue, expectedValue)
 			// make float64 compare with int64
-			if reflect.TypeOf(actualValue).Kind() == reflect.Float64 && reflect.TypeOf(expectedValue).Kind() == reflect.Int64 {
-				actualValue = int64(actualValue.(float64))
-			}
+			// if reflect.TypeOf(actualValue).Kind() == reflect.Float64 && reflect.TypeOf(expectedValue).Kind() == reflect.Int64 {
+			// 	actualValue = int64(actualValue.(float64))
+			// }
 
 			// not working there
 			//#[[assert.json]]
@@ -63,4 +90,95 @@ func DoJSONAssertions(jsonData interface{}, jsons []config.AssertJSON) (stats ut
 	}
 
 	return
+}
+
+func isNumberKind(kind reflect.Kind) bool {
+	switch kind {
+	case reflect.Int64,
+		reflect.Float64,
+		reflect.Int,
+		reflect.Float32,
+		reflect.Uint,
+		reflect.Uint8,
+		reflect.Uint16,
+		reflect.Uint32,
+		reflect.Uint64,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32:
+		return true
+	default:
+		return false
+	}
+}
+
+func isFloatKind(kind reflect.Kind) bool {
+	switch kind {
+	case reflect.Float64, reflect.Float32:
+		return true
+	default:
+		return false
+	}
+}
+
+func toInt64(i interface{}) (int64, error) {
+	switch s := i.(type) {
+	case int:
+		return int64(s), nil
+	case int64:
+		return s, nil
+	case int32:
+		return int64(s), nil
+	case int16:
+		return int64(s), nil
+	case int8:
+		return int64(s), nil
+	case uint:
+		return int64(s), nil
+	case uint64:
+		// NOTE: precision lost
+		return int64(s), nil
+	case uint32:
+		return int64(s), nil
+	case uint16:
+		return int64(s), nil
+	case uint8:
+		return int64(s), nil
+		// NOTE: only cast between int*, no float32/float64
+	default:
+		return 0, fmt.Errorf("unable to cast %#v of type %T to int64", i, i)
+	}
+}
+
+func toFloat64(i interface{}) (float64, error) {
+	switch s := i.(type) {
+	case float64:
+		return s, nil
+	case float32:
+		return float64(s), nil
+	case int:
+		return float64(s), nil
+	case int64:
+		// NOTE: precision lost
+		return float64(s), nil
+	case int32:
+		return float64(s), nil
+	case int16:
+		return float64(s), nil
+	case int8:
+		return float64(s), nil
+	case uint:
+		return float64(s), nil
+	case uint64:
+		// NOTE: precision lost
+		return float64(s), nil
+	case uint32:
+		return float64(s), nil
+	case uint16:
+		return float64(s), nil
+	case uint8:
+		return float64(s), nil
+	default:
+		return 0, fmt.Errorf("unable to cast %#v of type %T to float64", i, i)
+	}
 }


### PR DESCRIPTION
Bugfix:
1. response body length=0,  application/json will cause json decode EOF
2. assert header output with a `\n`
3. assert json, both number but type not the same(`int64(1) != float64(1)`), cast to same type then assert