### PR TITLE
feat(requests/build): support chain the requests, parse vars from first, use in the next

### DIFF
--- a/docs/Usage/build-request.md
+++ b/docs/Usage/build-request.md
@@ -329,6 +329,36 @@ DEBUG request:
 >
 ```
 
+## chain the requests
+
+you can chain the requests, the response of the previous request will be parsed and saved in the context, then you can use it in the next request
+
+```yaml
+
+```yaml
+request:
+  method: get
+  url: 'https://httpbin.org/get'
+assert:
+  status: ok
+  statusCode: 200
+parse:
+  - key: origin
+    source: body
+    jmespath: "origin"
+  - key: length
+    source: header
+    header: Content-Length
+---
+request:
+  method: get
+  url: 'https://httpbin.org/get'
+  header:
+    X-GOT-ORIGIN: '{{.origin}}'
+assert:
+  statusCode: 302
+```
+
 ## config: set a timeout for case
 
 ```yaml

--- a/docs/Usage/command-line.md
+++ b/docs/Usage/command-line.md
@@ -138,7 +138,6 @@ the config.yaml file example
 
 ```yaml
 debug: false
-render: true
 failFast: true
 timeout: 2000
 env:

--- a/docs/Usage/config.md
+++ b/docs/Usage/config.md
@@ -37,7 +37,6 @@ order:
   - pattern: examples/get.toml
   - pattern: examples/asserts.*
 
-render: true
 env:
   hello: world
   name: tom

--- a/docs/features.md
+++ b/docs/features.md
@@ -40,7 +40,6 @@ permalink: /features/
 
 - use a config file: `./httptest run -c examples/config/dev.toml examples/get.toml`
 - config: `debug=true/false` to trigger debug print
-- config: `render=true/false` to use  go_template render the `env`
 - config: `failFast=true/false`, will exit if got one fail case while running
 - config: `timeout=1000`, will set request timeout to 1000ms, fail if exceed
 

--- a/examples/chain_the_requests_json.yaml
+++ b/examples/chain_the_requests_json.yaml
@@ -1,0 +1,22 @@
+request:
+  method: get
+  url: 'https://httpbin.org/get'
+assert:
+  status: ok
+  statusCode: 200
+parse:
+  - key: origin
+    source: body
+    jmespath: "origin"
+  - key: length
+    source: header
+    header: Content-Length
+---
+request:
+  method: get
+  url: 'https://httpbin.org/get'
+  header:
+    X-GOT-ORIGIN: '{{.origin}}'
+    X-GOT-LENGTH: '{{.length}}'
+assert:
+  statusCode: 302

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,5 +1,4 @@
 debug: false
-render: true
 failFast: true
 timeout: 2000
 env:

--- a/examples/config_order.yaml
+++ b/examples/config_order.yaml
@@ -1,5 +1,4 @@
 debug: false
-render: true
 failFast: true
 timeout: 2000
 env:

--- a/pkg/config/case.go
+++ b/pkg/config/case.go
@@ -12,6 +12,15 @@ type Hook struct {
 	SaveCookie string `mapstructure:"save_cookie"`
 }
 
+type Parse struct {
+	Key    string `yaml:"key" mapstructure:"key"`
+	Source string `yaml:"source" mapstructure:"source"`
+	// body: json
+	Jmespath string `yaml:"jmespath" mapstructure:"jmespath"`
+	// header name
+	Header string `yaml:"header" mapstructure:"header"`
+}
+
 type Case struct {
 	Title       string
 	Description string
@@ -24,6 +33,8 @@ type Case struct {
 	Request Request
 	Assert  Assert
 	Hook    Hook
+
+	Parse []Parse
 
 	// caseIndex => {lineNo: lineContent}
 	FileLines map[int]map[int]string

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,9 +1,8 @@
 package config
 
 type RunConfig struct {
-	Debug  bool
-	Render bool
-	Env    map[string]interface{}
+	Debug bool
+	Env   map[string]interface{}
 
 	// exit 1 if got one assert fail
 	FailFast bool


### PR DESCRIPTION
```yaml
request:
  method: get
  url: 'https://httpbin.org/get'
assert:
  status: ok
  statusCode: 200
parse:
  - key: origin
    source: body
    jmespath: "origin"
  - key: length
    source: header
    header: Content-Length
---
request:
  method: get
  url: 'https://httpbin.org/get'
  header:
    X-GOT-ORIGIN: '{{.origin}}'
    X-GOT-LENGTH: '{{.length}}'
assert:
  statusCode: 302
```